### PR TITLE
refactor: Standardize all AST node classes

### DIFF
--- a/src/parser/BuildVisitors.cpp
+++ b/src/parser/BuildVisitors.cpp
@@ -53,11 +53,11 @@ void BuildOpcodes::deallocateRefsUntilCount(int count)
 void BuildOpcodes::caseBlock(ASTBlock &host, void *param)
 {
 	OpcodeContext *c = (OpcodeContext *)param;
-	list<ASTStmt*> l = host.getStatements();
 
 	int startRefCount = arrayRefs.size();
 
-    for (list<ASTStmt*>::iterator it = l.begin(); it != l.end(); it++)
+    for (vector<ASTStmt*>::iterator it = host.statements.begin();
+		 it != host.statements.end(); ++it)
 	{
 		int initIndex = result.size();
         (*it)->execute(*this, param);
@@ -73,12 +73,12 @@ void BuildOpcodes::caseBlock(ASTBlock &host, void *param)
 void BuildOpcodes::caseStmtIf(ASTStmtIf &host, void *param)
 {
     //run the test
-    host.getCondition()->execute(*this,param);
+    host.condition->execute(*this,param);
     int endif = ScriptParser::getUniqueLabelID();
     addOpcode(new OCompareImmediate(new VarArgument(EXP1), new LiteralArgument(0)));
     addOpcode(new OGotoTrueImmediate(new LabelArgument(endif)));
     //run the block
-    host.getStmt()->execute(*this,param);
+    host.thenStatement->execute(*this,param);
     //nop
     Opcode *next = new OSetImmediate(new VarArgument(EXP1), new LiteralArgument(0));
     next->setLabel(endif);
@@ -88,18 +88,18 @@ void BuildOpcodes::caseStmtIf(ASTStmtIf &host, void *param)
 void BuildOpcodes::caseStmtIfElse(ASTStmtIfElse &host, void *param)
 {
     //run the test
-    host.getCondition()->execute(*this,param);
+    host.condition->execute(*this,param);
     int elseif = ScriptParser::getUniqueLabelID();
     int endif = ScriptParser::getUniqueLabelID();
     addOpcode(new OCompareImmediate(new VarArgument(EXP1), new LiteralArgument(0)));
     addOpcode(new OGotoTrueImmediate(new LabelArgument(elseif)));
     //run if blocl
-    host.getStmt()->execute(*this,param);
+    host.thenStatement->execute(*this,param);
     addOpcode(new OGotoImmediate(new LabelArgument(endif)));
     Opcode *next = new OSetImmediate(new VarArgument(EXP2), new LiteralArgument(0));
     next->setLabel(elseif);
     addOpcode(next);
-    host.getElseStmt()->execute(*this,param);
+    host.elseStatement->execute(*this,param);
     next = new OSetImmediate(new VarArgument(EXP2), new LiteralArgument(0));
     next->setLabel(endif);
     addOpcode(next);
@@ -108,7 +108,7 @@ void BuildOpcodes::caseStmtIfElse(ASTStmtIfElse &host, void *param)
 void BuildOpcodes::caseStmtSwitch(ASTStmtSwitch &host, void* param)
 {
 	map<ASTSwitchCases*, int> labels;
-	vector<ASTSwitchCases*> cases = host.getCases();
+	vector<ASTSwitchCases*>& cases = host.cases;
 
 	int end_label = ScriptParser::getUniqueLabelID();;
 	int default_label = end_label;
@@ -120,7 +120,7 @@ void BuildOpcodes::caseStmtSwitch(ASTStmtSwitch &host, void* param)
 	breakRefCount = arrayRefs.size();
 
 	// Evaluate the key.
-	ASTExpr* key = host.getKey();
+	ASTExpr* key = host.key;
 	key->execute(*this, param);
 	result.push_back(new OSetRegister(new VarArgument(EXP2), new VarArgument(EXP1)));
 
@@ -134,8 +134,8 @@ void BuildOpcodes::caseStmtSwitch(ASTStmtSwitch &host, void* param)
 		labels[cases] = label;
 
 		// Run the tests for these cases.
-		for (vector<ASTExprConst*>::iterator it = cases->getCases().begin();
-			 it != cases->getCases().end();
+		for (vector<ASTExprConst*>::iterator it = cases->cases.begin();
+			 it != cases->cases.end();
 			 ++it)
 		{
 			// Test this individual case.
@@ -148,7 +148,7 @@ void BuildOpcodes::caseStmtSwitch(ASTStmtSwitch &host, void* param)
 		}
 
 		// If this set includes the default case, mark it.
-		if (cases->isDefaultCase())
+		if (cases->isDefault)
 			default_label = label;
 	}
 
@@ -163,7 +163,7 @@ void BuildOpcodes::caseStmtSwitch(ASTStmtSwitch &host, void* param)
 		// Mark start of the block we're adding.
 		int block_start_index = result.size();
 		// Add block.
-		cases->getBlock()->execute(*this, param);
+		cases->block->execute(*this, param);
 		// If nothing was added, put in a nop to point to.
 		if (result.size() == block_start_index)
 			result.push_back(new OSetImmediate(new VarArgument(EXP2), new LiteralArgument(0)));
@@ -184,7 +184,7 @@ void BuildOpcodes::caseStmtSwitch(ASTStmtSwitch &host, void* param)
 void BuildOpcodes::caseStmtFor(ASTStmtFor &host, void *param)
 {
     //run the precondition
-    host.getPrecondition()->execute(*this,param);
+    host.setup->execute(*this,param);
     int loopstart = ScriptParser::getUniqueLabelID();
     int loopend = ScriptParser::getUniqueLabelID();
     int loopincr = ScriptParser::getUniqueLabelID();
@@ -193,7 +193,7 @@ void BuildOpcodes::caseStmtFor(ASTStmtFor &host, void *param)
     next->setLabel(loopstart);
     addOpcode(next);
     //test the termination condition
-    host.getTerminationCondition()->execute(*this,param);
+    host.test->execute(*this,param);
     addOpcode(new OCompareImmediate(new VarArgument(EXP1), new LiteralArgument(0)));
     addOpcode(new OGotoTrueImmediate(new LabelArgument(loopend)));
     //run the loop body
@@ -208,7 +208,7 @@ void BuildOpcodes::caseStmtFor(ASTStmtFor &host, void *param)
     continuelabelid = loopincr;
 	continueRefCount = arrayRefs.size();
 
-    host.getStmt()->execute(*this,param);
+    host.body->execute(*this,param);
 
     breaklabelid = oldbreak;
     breakRefCount = oldBreakRefCount;
@@ -220,7 +220,7 @@ void BuildOpcodes::caseStmtFor(ASTStmtFor &host, void *param)
     next = new OSetImmediate(new VarArgument(EXP2), new LiteralArgument(0));
     next->setLabel(loopincr);
     addOpcode(next);
-    host.getIncrement()->execute(*this,param);
+    host.increment->execute(*this,param);
     addOpcode(new OGotoImmediate(new LabelArgument(loopstart)));
     //nop
     next = new OSetImmediate(new VarArgument(EXP2), new LiteralArgument(0));
@@ -237,7 +237,7 @@ void BuildOpcodes::caseStmtWhile(ASTStmtWhile &host, void *param)
     Opcode *start = new OSetImmediate(new VarArgument(EXP1), new LiteralArgument(0));
     start->setLabel(startlabel);
     addOpcode(start);
-    host.getCond()->execute(*this,param);
+    host.test->execute(*this,param);
     addOpcode(new OCompareImmediate(new VarArgument(EXP1), new LiteralArgument(0)));
     addOpcode(new OGotoTrueImmediate(new LabelArgument(endlabel)));
 
@@ -250,7 +250,7 @@ void BuildOpcodes::caseStmtWhile(ASTStmtWhile &host, void *param)
     continuelabelid = startlabel;
 	continueRefCount = arrayRefs.size();
 
-    host.getStmt()->execute(*this,param);
+    host.body->execute(*this,param);
 
     breaklabelid = oldbreak;
 	breakRefCount = oldBreakRefCount;
@@ -283,7 +283,7 @@ void BuildOpcodes::caseStmtDo(ASTStmtDo &host, void *param)
     continuelabelid = continuelabel;
 	continueRefCount = arrayRefs.size();
 
-    host.getStmt()->execute(*this, param);
+    host.body->execute(*this, param);
 
     breaklabelid = oldbreak;
     continuelabelid = oldcontinue;
@@ -293,7 +293,7 @@ void BuildOpcodes::caseStmtDo(ASTStmtDo &host, void *param)
     start = new OSetImmediate(new VarArgument(NUL), new LiteralArgument(0));
     start->setLabel(continuelabel);
     addOpcode(start);
-    host.getCond()->execute(*this,param);
+    host.test->execute(*this,param);
     addOpcode(new OCompareImmediate(new VarArgument(EXP1), new LiteralArgument(0)));
     addOpcode(new OGotoTrueImmediate(new LabelArgument(endlabel)));
     addOpcode(new OGotoImmediate(new LabelArgument(startlabel)));
@@ -311,7 +311,7 @@ void BuildOpcodes::caseStmtReturn(ASTStmtReturn&, void*)
 
 void BuildOpcodes::caseStmtReturnVal(ASTStmtReturnVal &host, void *param)
 {
-    host.getReturnValue()->execute(*this, param);
+    host.value->execute(*this, param);
 	deallocateRefsUntilCount(0);
     addOpcode(new OGotoImmediate(new LabelArgument(returnlabelid)));
 }
@@ -368,7 +368,7 @@ void BuildOpcodes::caseDataDecl(ASTDataDecl& host, void* param)
 	// Switch off to the proper helper function.
 	if (manager.type->typeClassId() == ZVARTYPE_CLASSID_ARRAY)
 	{
-		if (host.getInitializer()) buildArrayInit(host, context);
+		if (host.initializer()) buildArrayInit(host, context);
 		else buildArrayUninit(host, context);
 	}
 	else buildVariable(host, context);
@@ -379,13 +379,13 @@ void BuildOpcodes::buildVariable(ASTDataDecl& host, OpcodeContext& context)
 	Variable& manager = *host.manager;
 
 	// Load initializer into EXP1, if present.
-	if (host.getInitializer()) host.getInitializer()->execute(*this, &context);
+	AST::execute(host.initializer(), *this, &context);
 
 	// Set variable to EXP1 or 0, depending on the initializer.
 	if (manager.global)
 	{
 		int globalid = context.linktable->getGlobalID(manager.id);
-		if (host.getInitializer())
+		if (host.initializer())
 			addOpcode(new OSetRegister(new GlobalArgument(globalid), new VarArgument(EXP1)));
 		else
 			addOpcode(new OSetImmediate(new GlobalArgument(globalid), new LiteralArgument(0)));
@@ -395,7 +395,7 @@ void BuildOpcodes::buildVariable(ASTDataDecl& host, OpcodeContext& context)
 		int offset = context.stackframe->getOffset(manager.id);
 		addOpcode(new OSetRegister(new VarArgument(SFTEMP), new VarArgument(SFRAME)));
 		addOpcode(new OAddImmediate(new VarArgument(SFTEMP), new LiteralArgument(offset)));
-		if (!host.getInitializer())
+		if (!host.initializer())
 			addOpcode(new OSetImmediate(new VarArgument(EXP1), new LiteralArgument(0)));
 		addOpcode(new OStoreIndirect(new VarArgument(EXP1), new VarArgument(SFTEMP)));
 	}
@@ -406,7 +406,7 @@ void BuildOpcodes::buildArrayInit(ASTDataDecl& host, OpcodeContext& context)
 	Variable& manager = *host.manager;
 
 	// Initializer creates the array and loads the array id into EXP1.
-	host.getInitializer()->execute(*this, &context);
+	host.initializer()->execute(*this, &context);
 
 	// Set variable to EXP1.
 	if (manager.global)
@@ -496,10 +496,10 @@ void BuildOpcodes::caseCompileError(ASTCompileError& host, void*)
 void BuildOpcodes::caseExprAssign(ASTExprAssign &host, void *param)
 {
     //load the rval into EXP1
-    host.getRVal()->execute(*this,param);
+    host.right->execute(*this, param);
     //and store it
     LValBOHelper helper;
-    host.getLVal()->execute(helper, param);
+    host.left->execute(helper, param);
     vector<Opcode *> subcode = helper.getResult();
 
     for(vector<Opcode *>::iterator it = subcode.begin(); it != subcode.end(); it++)
@@ -510,7 +510,7 @@ void BuildOpcodes::caseExprAssign(ASTExprAssign &host, void *param)
 
 void BuildOpcodes::caseExprConst(ASTExprConst &host, void *param)
 {
-	host.getContent()->execute(*this, param);
+	AST::execute(host.content, *this, param);
 }
 
 void BuildOpcodes::caseExprIdentifier(ASTExprIdentifier& host, void* param)
@@ -545,7 +545,7 @@ void BuildOpcodes::caseExprIdentifier(ASTExprIdentifier& host, void* param)
 void BuildOpcodes::caseExprArrow(ASTExprArrow& host, void* param)
 {
     OpcodeContext* c = (OpcodeContext*)param;
-    bool isIndexed = host.getIndex() != NULL;
+    bool isIndexed = host.index != NULL;
     //this is actually a function call
     //to the appropriate gettor method
     //so, set that up:
@@ -556,13 +556,13 @@ void BuildOpcodes::caseExprArrow(ASTExprArrow& host, void* param)
     addOpcode(new OSetImmediate(new VarArgument(EXP1), new LabelArgument(returnlabel)));
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
     //get the rhs of the arrow
-    host.getLeft()->execute(*this, param);
+    AST::execute(host.left, *this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
 
     //if indexed, push the index
     if(isIndexed)
     {
-        host.getIndex()->execute(*this,param);
+        AST::execute(host.index, *this, param);
         addOpcode(new OPushRegister(new VarArgument(EXP1)));
     }
 
@@ -578,18 +578,18 @@ void BuildOpcodes::caseExprArrow(ASTExprArrow& host, void* param)
 void BuildOpcodes::caseExprIndex(ASTExprIndex& host, void* param)
 {
 	// If the left hand side is an arrow, then we'll let it run instead.
-	if (host.getArray()->isTypeArrow())
+	if (host.array->isTypeArrow())
 	{
-		host.getArray()->execute(*this, param);
+		host.array->execute(*this, param);
 		return;
 	}
 
 	// First, push the array.
-	host.getArray()->execute(*this, param);
+	AST::execute(host.array, *this, param);
 	addOpcode(new OPushRegister(new VarArgument(EXP1)));
 
 	// Load the index into INDEX2.
-	host.getIndex()->execute(*this, param);
+	AST::execute(host.index, *this, param);
 	addOpcode(new OSetRegister(new VarArgument(INDEX2), new VarArgument(EXP1)));
 
 	// Pop array into INDEX.
@@ -614,17 +614,18 @@ void BuildOpcodes::caseExprCall(ASTExprCall& host, void* param)
 
     // If the function is a pointer function (->func()) we need to push the
     // left-hand-side.
-    if (host.getLeft()->isTypeArrow())
+    if (host.left->isTypeArrow())
     {
         //load the value of the left-hand of the arrow into EXP1
-        ((ASTExprArrow*)host.getLeft())->getLeft()->execute(*this, param);
+        ((ASTExprArrow*)host.left)->left->execute(*this, param);
         //host.getLeft()->execute(*this,param);
         //push it onto the stack
         addOpcode(new OPushRegister(new VarArgument(EXP1)));
     }
 
     //push the parameters, in forward order
-    for(list<ASTExpr *>::iterator it = host.getParams().begin(); it != host.getParams().end(); it++)
+    for (vector<ASTExpr*>::iterator it = host.parameters.begin();
+		it != host.parameters.end(); ++it)
     {
         (*it)->execute(*this, param);
         addOpcode(new OPushRegister(new VarArgument(EXP1)));
@@ -646,7 +647,7 @@ void BuildOpcodes::caseExprNegate(ASTExprNegate& host, void* param)
         return;
     }
 
-    host.getOperand()->execute(*this, param);
+    host.operand->execute(*this, param);
     addOpcode(new OSetImmediate(new VarArgument(EXP2), new LiteralArgument(0)));
     addOpcode(new OSubRegister(new VarArgument(EXP2), new VarArgument(EXP1)));
     addOpcode(new OSetRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
@@ -660,7 +661,7 @@ void BuildOpcodes::caseExprNot(ASTExprNot& host, void* param)
         return;
     }
 
-    host.getOperand()->execute(*this, param);
+    host.operand->execute(*this, param);
     addOpcode(new OCompareImmediate(new VarArgument(EXP1), new LiteralArgument(0)));
     addOpcode(new OSetTrue(new VarArgument(EXP1)));
 }
@@ -673,7 +674,7 @@ void BuildOpcodes::caseExprBitNot(ASTExprBitNot& host, void* param)
         return;
     }
 
-    host.getOperand()->execute(*this, param);
+    host.operand->execute(*this, param);
     addOpcode(new ONot(new VarArgument(EXP1)));
 }
 
@@ -683,21 +684,21 @@ void BuildOpcodes::caseExprIncrement(ASTExprIncrement& host, void* param)
 
     // Load value of the variable into EXP1.  Except if it is an arrow expr, in
     // which case the gettor function is stored in this AST*.
-	ASTExpr& operand = *host.getOperand();
+	ASTExpr& operand = *host.operand;
 	if (operand.isTypeArrow() || operand.isTypeIndex())
 	{
 		ASTExprArrow* arrow;
 		if (operand.isTypeArrow()) arrow = &(ASTExprArrow&)operand;
-		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).getArray();
+		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).array;
 
         int oldid = c->symbols->getNodeId(arrow);
         c->symbols->putNodeId(arrow, c->symbols->getNodeId(&host));
-        host.getOperand()->execute(*this,param);
+        host.operand->execute(*this,param);
         c->symbols->putNodeId(arrow, oldid);
     }
-    else if (host.getOperand()->isTypeIdentifier())
+    else if (host.operand->isTypeIdentifier())
     {
-        host.getOperand()->execute(*this, param);
+        host.operand->execute(*this, param);
     }
 
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
@@ -706,7 +707,7 @@ void BuildOpcodes::caseExprIncrement(ASTExprIncrement& host, void* param)
     addOpcode(new OAddImmediate(new VarArgument(EXP1), new LiteralArgument(10000)));
     //store it
     LValBOHelper helper;
-    host.getOperand()->execute(helper, param);
+    host.operand->execute(helper, param);
     vector<Opcode *> subcode = helper.getResult();
 
     for(vector<Opcode *>::iterator it = subcode.begin(); it != subcode.end(); it++)
@@ -724,28 +725,28 @@ void BuildOpcodes::caseExprPreIncrement(ASTExprPreIncrement& host, void* param)
 
     // Load value of the variable into EXP1.  Except if it is an arrow expr, in
     // which case the gettor function is stored in this AST*.
-	ASTExpr& operand = *host.getOperand();
+	ASTExpr& operand = *host.operand;
 	if (operand.isTypeArrow() || operand.isTypeIndex())
 	{
 		ASTExprArrow* arrow;
 		if (operand.isTypeArrow()) arrow = &(ASTExprArrow&)operand;
-		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).getArray();
+		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).array;
 
         int oldid = c->symbols->getNodeId(arrow);
         c->symbols->putNodeId(arrow, c->symbols->getNodeId(&host));
-        host.getOperand()->execute(*this,param);
+        host.operand->execute(*this,param);
         c->symbols->putNodeId(arrow, oldid);
     }
-    else if (host.getOperand()->isTypeIdentifier())
+    else if (host.operand->isTypeIdentifier())
     {
-        host.getOperand()->execute(*this, param);
+        host.operand->execute(*this, param);
     }
 
     //increment EXP1
     addOpcode(new OAddImmediate(new VarArgument(EXP1), new LiteralArgument(10000)));
     //store it
     LValBOHelper helper;
-    host.getOperand()->execute(helper, param);
+    host.operand->execute(helper, param);
     vector<Opcode *> subcode = helper.getResult();
 
     for(vector<Opcode *>::iterator it = subcode.begin(); it != subcode.end(); it++)
@@ -759,28 +760,28 @@ void BuildOpcodes::caseExprPreDecrement(ASTExprPreDecrement& host, void* param)
     OpcodeContext* c = (OpcodeContext*)param;
     // Load value of the variable into EXP1 Except if it is an arrow expr, in
     // which case the gettor function is stored in this AST*.
-	ASTExpr& operand = *host.getOperand();
+	ASTExpr& operand = *host.operand;
 	if (operand.isTypeArrow() || operand.isTypeIndex())
 	{
 		ASTExprArrow* arrow;
 		if (operand.isTypeArrow()) arrow = &(ASTExprArrow&)operand;
-		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).getArray();
+		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).array;
 
         int oldid = c->symbols->getNodeId(arrow);
         c->symbols->putNodeId(arrow, c->symbols->getNodeId(&host));
-        host.getOperand()->execute(*this,param);
+        host.operand->execute(*this,param);
         c->symbols->putNodeId(arrow, oldid);
     }
-    else if (host.getOperand()->isTypeIdentifier())
+    else if (host.operand->isTypeIdentifier())
     {
-        host.getOperand()->execute(*this, param);
+        host.operand->execute(*this, param);
     }
 
     //dencrement EXP1
     addOpcode(new OSubImmediate(new VarArgument(EXP1), new LiteralArgument(10000)));
     //store it
     LValBOHelper helper;
-    host.getOperand()->execute(helper, param);
+    host.operand->execute(helper, param);
     vector<Opcode *> subcode = helper.getResult();
 
     for(vector<Opcode *>::iterator it = subcode.begin(); it != subcode.end(); it++)
@@ -794,21 +795,21 @@ void BuildOpcodes::caseExprDecrement(ASTExprDecrement& host, void* param)
     OpcodeContext* c = (OpcodeContext*)param;
     // Load value of the variable into EXP1 except if it is an arrow expr, in
     // which case the gettor function is stored in this AST*.
-	ASTExpr& operand = *host.getOperand();
+	ASTExpr& operand = *host.operand;
 	if (operand.isTypeArrow() || operand.isTypeIndex())
 	{
 		ASTExprArrow* arrow;
 		if (operand.isTypeArrow()) arrow = &(ASTExprArrow&)operand;
-		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).getArray();
+		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).array;
 
         int oldid = c->symbols->getNodeId(arrow);
         c->symbols->putNodeId(arrow, c->symbols->getNodeId(&host));
-        host.getOperand()->execute(*this,param);
+        host.operand->execute(*this,param);
         c->symbols->putNodeId(arrow, oldid);
     }
-    else if (host.getOperand()->isTypeIdentifier())
+    else if (host.operand->isTypeIdentifier())
     {
-        host.getOperand()->execute(*this, param);
+        host.operand->execute(*this, param);
     }
 
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
@@ -817,7 +818,7 @@ void BuildOpcodes::caseExprDecrement(ASTExprDecrement& host, void* param)
     addOpcode(new OSubImmediate(new VarArgument(EXP1), new LiteralArgument(10000)));
     //store it
     LValBOHelper helper;
-    host.getOperand()->execute(helper, param);
+    host.operand->execute(helper, param);
     vector<Opcode *> subcode = helper.getResult();
 
     for(vector<Opcode *>::iterator it = subcode.begin(); it != subcode.end(); it++)
@@ -838,9 +839,9 @@ void BuildOpcodes::caseExprAnd(ASTExprAnd& host, void* param)
     }
 
     //compute both sides
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     castFromBool(result, EXP1);
     castFromBool(result, EXP2);
@@ -858,9 +859,9 @@ void BuildOpcodes::caseExprOr(ASTExprOr& host, void* param)
     }
 
     //compute both sides
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this,param);
+    host.right->execute(*this,param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OAddRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
     addOpcode(new OCompareImmediate(new VarArgument(EXP1), new LiteralArgument(1)));
@@ -876,9 +877,9 @@ void BuildOpcodes::caseExprGT(ASTExprGT& host, void* param)
     }
 
     //compute both sides
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OCompareRegister(new VarArgument(EXP2), new VarArgument(EXP1)));
     addOpcode(new OSetLess(new VarArgument(EXP1)));
@@ -895,9 +896,9 @@ void BuildOpcodes::caseExprGE(ASTExprGE& host, void* param)
     }
 
     //compute both sides
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OCompareRegister(new VarArgument(EXP2), new VarArgument(EXP1)));
     addOpcode(new OSetMore(new VarArgument(EXP1)));
@@ -912,9 +913,9 @@ void BuildOpcodes::caseExprLT(ASTExprLT& host, void* param)
     }
 
     //compute both sides
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OCompareRegister(new VarArgument(EXP2), new VarArgument(EXP1)));
     addOpcode(new OSetMore(new VarArgument(EXP1)));
@@ -931,9 +932,9 @@ void BuildOpcodes::caseExprLE(ASTExprLE& host, void* param)
     }
 
     // Compute both sides.
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OCompareRegister(new VarArgument(EXP2), new VarArgument(EXP1)));
     addOpcode(new OSetLess(new VarArgument(EXP1)));
@@ -942,7 +943,7 @@ void BuildOpcodes::caseExprLE(ASTExprLE& host, void* param)
 void BuildOpcodes::caseExprEQ(ASTExprEQ& host, void* param)
 {
     // Special case for booleans.
-    bool isBoolean = (*host.getFirstOperand()->getVarType() == ZVarType::BOOL);
+    bool isBoolean = (*host.left->getVarType() == ZVarType::BOOL);
 
     if (host.hasDataValue())
     {
@@ -951,9 +952,9 @@ void BuildOpcodes::caseExprEQ(ASTExprEQ& host, void* param)
     }
 
     // Compute both sides.
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
 
     if (isBoolean)
@@ -969,7 +970,7 @@ void BuildOpcodes::caseExprEQ(ASTExprEQ& host, void* param)
 void BuildOpcodes::caseExprNE(ASTExprNE& host, void* param)
 {
     // Special case for booleans.
-    bool isBoolean = (*host.getFirstOperand()->getVarType() == ZVarType::BOOL);
+    bool isBoolean = (*host.left->getVarType() == ZVarType::BOOL);
 
     if (host.hasDataValue())
     {
@@ -978,9 +979,9 @@ void BuildOpcodes::caseExprNE(ASTExprNE& host, void* param)
     }
 
     // Compute both sides.
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
 
     if (isBoolean)
@@ -1002,9 +1003,9 @@ void BuildOpcodes::caseExprPlus(ASTExprPlus& host, void* param)
     }
 
     // Compute both sides.
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OAddRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
 }
@@ -1018,9 +1019,9 @@ void BuildOpcodes::caseExprMinus(ASTExprMinus& host, void* param)
     }
 
     // Compute both sides.
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OSubRegister(new VarArgument(EXP2), new VarArgument(EXP1)));
     addOpcode(new OSetRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
@@ -1035,9 +1036,9 @@ void BuildOpcodes::caseExprTimes(ASTExprTimes& host, void *param)
     }
 
     // Compute both sides.
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OMultRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
 }
@@ -1051,9 +1052,9 @@ void BuildOpcodes::caseExprDivide(ASTExprDivide& host, void* param)
     }
 
     // Compute both sides.
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new ODivRegister(new VarArgument(EXP2), new VarArgument(EXP1)));
     addOpcode(new OSetRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
@@ -1068,9 +1069,9 @@ void BuildOpcodes::caseExprModulo(ASTExprModulo& host, void* param)
     }
 
     // Compute both sides.
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OModuloRegister(new VarArgument(EXP2), new VarArgument(EXP1)));
     addOpcode(new OSetRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
@@ -1085,9 +1086,9 @@ void BuildOpcodes::caseExprBitAnd(ASTExprBitAnd& host, void* param)
     }
 
     // Compute both sides.
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OAndRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
 }
@@ -1101,9 +1102,9 @@ void BuildOpcodes::caseExprBitOr(ASTExprBitOr& host, void* param)
     }
 
     // Compute both sides.
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OOrRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
 }
@@ -1117,9 +1118,9 @@ void BuildOpcodes::caseExprBitXor(ASTExprBitXor& host, void* param)
     }
 
     // Compute both sides.
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OXorRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
 }
@@ -1133,9 +1134,9 @@ void BuildOpcodes::caseExprLShift(ASTExprLShift& host, void* param)
     }
 
     // Compute both sides.
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new OLShiftRegister(new VarArgument(EXP2), new VarArgument(EXP1)));
     addOpcode(new OSetRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
@@ -1150,9 +1151,9 @@ void BuildOpcodes::caseExprRShift(ASTExprRShift& host, void* param)
     }
 
     // Compute both sides.
-    host.getFirstOperand()->execute(*this, param);
+    host.left->execute(*this, param);
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
-    host.getSecondOperand()->execute(*this, param);
+    host.right->execute(*this, param);
     addOpcode(new OPopRegister(new VarArgument(EXP2)));
     addOpcode(new ORShiftRegister(new VarArgument(EXP2), new VarArgument(EXP1)));
     addOpcode(new OSetRegister(new VarArgument(EXP1), new VarArgument(EXP2)));
@@ -1166,11 +1167,11 @@ void BuildOpcodes::caseNumberLiteral(ASTNumberLiteral& host, void*)
         addOpcode(new OSetImmediate(new VarArgument(EXP1), new LiteralArgument(host.getDataValue())));
     else
     {
-        pair<long, bool> val = ScriptParser::parseLong(host.getValue()->parseValue());
+        pair<long, bool> val = ScriptParser::parseLong(host.value->parseValue());
 
         if (!val.second)
             compileError(host, &CompileError::ConstTrunc,
-						 host.getValue()->getValue());
+						 host.value->value);
 
         addOpcode(new OSetImmediate(new VarArgument(EXP1), new LiteralArgument(val.first)));
     }
@@ -1191,7 +1192,7 @@ void BuildOpcodes::caseStringLiteral(ASTStringLiteral& host, void* param)
 	////////////////////////////////////////////////////////////////
 	// Initialization Code.
 
-	string data = host.getValue();
+	string data = host.value;
 	long size = (data.size() + 1) * 10000L;
 
 	// If this is part of an array declaration, grab the size info from it.
@@ -1426,7 +1427,7 @@ void LValBOHelper::caseExprIdentifier(ASTExprIdentifier& host, void* param)
 void LValBOHelper::caseExprArrow(ASTExprArrow &host, void *param)
 {
     OpcodeContext *c = (OpcodeContext *)param;
-    int isIndexed = (host.getIndex() != NULL);
+    int isIndexed = (host.index != NULL);
     // This is actually implemented as a settor function call.
 
     // Push the stack frame.
@@ -1441,7 +1442,7 @@ void LValBOHelper::caseExprArrow(ASTExprArrow &host, void *param)
     addOpcode(new OPushRegister(new VarArgument(EXP1)));
     vector<Opcode *> toadd;
     BuildOpcodes oc;
-    host.getLeft()->execute(oc, param);
+    host.left->execute(oc, param);
     toadd = oc.getResult();
     
     for(vector<Opcode *>::iterator it = toadd.begin(); it != toadd.end(); it++)
@@ -1460,7 +1461,7 @@ void LValBOHelper::caseExprArrow(ASTExprArrow &host, void *param)
     if(isIndexed)
     {
         BuildOpcodes oc2;
-        host.getIndex()->execute(oc2, param);
+        host.index->execute(oc2, param);
         toadd = oc2.getResult();
         
         for(vector<Opcode *>::iterator it = toadd.begin(); it != toadd.end(); it++)
@@ -1484,9 +1485,9 @@ void LValBOHelper::caseExprArrow(ASTExprArrow &host, void *param)
 void LValBOHelper::caseExprIndex(ASTExprIndex& host, void* param)
 {
 	// Arrows just fall back on the arrow implementation.
-	if (host.getArray()->isTypeArrow())
+	if (host.array->isTypeArrow())
 	{
-		host.getArray()->execute(*this, param);
+		host.array->execute(*this, param);
 		return;
 	}
 
@@ -1497,7 +1498,7 @@ void LValBOHelper::caseExprIndex(ASTExprIndex& host, void* param)
 
 	// Get and push the array pointer.
 	BuildOpcodes buildOpcodes1;
-	host.getArray()->execute(buildOpcodes1, param);
+	host.array->execute(buildOpcodes1, param);
 	opcodes = buildOpcodes1.getResult();
 	for (vector<Opcode*>::iterator it = opcodes.begin(); it != opcodes.end(); ++it)
 		addOpcode(*it);
@@ -1505,7 +1506,7 @@ void LValBOHelper::caseExprIndex(ASTExprIndex& host, void* param)
 
 	// Get the index.
 	BuildOpcodes buildOpcodes2;
-	host.getIndex()->execute(buildOpcodes2, param);
+	host.index->execute(buildOpcodes2, param);
 	opcodes = buildOpcodes2.getResult();
 	for (vector<Opcode*>::iterator it = opcodes.begin(); it != opcodes.end(); ++it)
 		addOpcode(*it);

--- a/src/parser/BuildVisitors.h
+++ b/src/parser/BuildVisitors.h
@@ -126,11 +126,7 @@ public:
 	virtual void caseBlock(ASTBlock &host, void *param)
 	{
 		prevframes.push(curoffset);
-		list<ASTStmt *> l = host.getStatements();
-
-		for (list<ASTStmt *>::iterator it = l.begin(); it != l.end(); it++)
-			(*it)->execute(*this, param);
-
+		AST::execute(host.statements, *this, param);
 		curoffset = prevframes.top();
 		prevframes.pop();
 	}
@@ -139,10 +135,10 @@ public:
 	{
 		prevframes.push(curoffset);
 
-		host.getPrecondition()->execute(*this, param);
-		host.getIncrement()->execute(*this, param);
-		host.getTerminationCondition()->execute(*this, param);
-		host.getStmt()->execute(*this, param);
+		host.setup->execute(*this, param);
+		host.increment->execute(*this, param);
+		host.test->execute(*this, param);
+		host.body->execute(*this, param);
 
 		curoffset = prevframes.top();
 		prevframes.pop();

--- a/src/parser/CompileError.cpp
+++ b/src/parser/CompileError.cpp
@@ -33,7 +33,7 @@ void CompileError::vprint(AST* offender, va_list args) const
 	// Output location data.
     if (offender)
     {
-        LocationData const& ld = offender->getLocation();
+        LocationData const& ld = offender->location;
         oss << ld.fname << ", line " << ld.first_line << ": ";
     }
 

--- a/src/parser/CompilerUtils.h
+++ b/src/parser/CompilerUtils.h
@@ -1,0 +1,24 @@
+// Various utility functions for the compiler.
+
+#ifndef ZSCRIPT_COMPILER_UTILS_H
+#define ZSCRIPT_COMPILER_UTILS_H
+
+// Delete all the elements in a vector of pointers.
+template<class Element>
+void deleteElements(vector<Element*>& container)
+{
+	for (typename vector<Element*>::iterator it = container.begin();
+		 it != container.end(); ++it)
+		delete *it;
+}
+
+// Delete all the elements in a list of pointers.
+template<class Element>
+void deleteElements(list<Element*>& container)
+{
+	for (typename list<Element*>::iterator it = container.begin();
+		 it != container.end(); ++it)
+		delete *it;
+}
+
+#endif

--- a/src/parser/ScriptParser.cpp
+++ b/src/parser/ScriptParser.cpp
@@ -152,7 +152,7 @@ bool ScriptParser::preprocess(ASTProgram* theAST, int reclimit)
     for (vector<ASTImportDecl*>::iterator it = imports.begin();
 		 it != imports.end(); it = imports.erase(it))
     {
-        string fn = prepareFilename((*it)->getFilename());
+        string fn = prepareFilename((*it)->filename);
 
         if (go(fn.c_str()) != 0 || !resAST)
         {
@@ -430,8 +430,8 @@ IntermediateData* ScriptParser::generateOCode(FunctionData* fdata)
 		offset = assign.getHighWaterOffset();
         
         //finally, assign the parameters, in reverse order
-		for (vector<ASTDataDecl*>::const_reverse_iterator it = node.getParameters().rbegin();
-			 it != node.getParameters().rend(); ++it)
+		for (vector<ASTDataDecl*>::const_reverse_iterator it = node.parameters.rbegin();
+			 it != node.parameters.rend(); ++it)
 		{
 			int vid = symbols->getNodeId(*it);
 			sf.addToFrame(vid, offset);

--- a/src/parser/TypeChecker.cpp
+++ b/src/parser/TypeChecker.cpp
@@ -34,7 +34,7 @@ void TypeCheck::caseStmtIf(ASTStmtIf& host, void*)
     RecursiveVisitor::caseStmtIf(host);
     if (failure) return;
 
-    ZVarType const& type = *host.getCondition()->getVarType();
+    ZVarType const& type = *host.condition->getVarType();
 
     if (!standardCheck(ZVARTYPEID_BOOL, type, &host))
         failure = true;
@@ -43,7 +43,7 @@ void TypeCheck::caseStmtIf(ASTStmtIf& host, void*)
 void TypeCheck::caseStmtIfElse(ASTStmtIfElse& host, void*)
 {
     caseStmtIf(host);
-    host.getElseStmt()->execute(*this);
+    host.elseStatement->execute(*this);
 }
 
 void TypeCheck::caseStmtSwitch(ASTStmtSwitch& host, void*)
@@ -51,7 +51,7 @@ void TypeCheck::caseStmtSwitch(ASTStmtSwitch& host, void*)
 	RecursiveVisitor::caseStmtSwitch(host);
 	if (failure) return;
 
-	ZVarType const& type = *host.getKey()->getVarType();
+	ZVarType const& type = *host.key->getVarType();
 	if (!standardCheck(ZVARTYPEID_FLOAT, type, &host))
 		failure = true;
 }
@@ -61,7 +61,7 @@ void TypeCheck::caseStmtFor(ASTStmtFor& host, void*)
     RecursiveVisitor::caseStmtFor(host);
     if (failure) return;
 
-    ZVarType const& type = *host.getTerminationCondition()->getVarType();
+    ZVarType const& type = *host.test->getVarType();
     if (!standardCheck(ZVARTYPEID_BOOL, type, &host))
         failure = true;
 }
@@ -71,7 +71,7 @@ void TypeCheck::caseStmtWhile(ASTStmtWhile& host, void*)
     RecursiveVisitor::caseStmtWhile(host);
     if (failure) return;
 
-    ZVarType const& type = *host.getCond()->getVarType();
+    ZVarType const& type = *host.test->getVarType();
     if (!standardCheck(ZVARTYPEID_BOOL, type, &host))
         failure = true;
 }
@@ -86,10 +86,10 @@ void TypeCheck::caseStmtReturn(ASTStmtReturn& host, void*)
 
 void TypeCheck::caseStmtReturnVal(ASTStmtReturnVal& host, void*)
 {
-    host.getReturnValue()->execute(*this);
+    host.value->execute(*this);
     if (failure) return;
 
-    if (!standardCheck(symbolTable.getTypeId(returnType), *host.getReturnValue()->getVarType(), &host))
+    if (!standardCheck(symbolTable.getTypeId(returnType), *host.value->getVarType(), &host))
         failure = true;
 }
 
@@ -106,25 +106,25 @@ void TypeCheck::caseDataDecl(ASTDataDecl& host, void*)
 	if (*variable.type == ZVarType::CONST_FLOAT)
 	{
 		// A constant without an initializer doesn't make sense.
-		if (!host.getInitializer())
+		if (!host.initializer())
 		{
 			compileError(host, &CompileError::ConstUninitialized);
 			return;
 		}
 
 		// Inline the constant if possible.
-		if (host.getInitializer()->hasDataValue())
+		if (host.initializer()->hasDataValue())
 		{
-			symbolTable.inlineConstant(&host, host.getInitializer()->getDataValue());
+			symbolTable.inlineConstant(&host, host.initializer()->getDataValue());
 			variable.inlined = true;
 		}
 	}
 
 	// Does it have an initializer?
-	if (host.getInitializer())
+	if (host.initializer())
 	{
 		// Make sure we can cast the initializer to the type.
-		ZVarType const& initType = *host.getInitializer()->getVarType();
+		ZVarType const& initType = *host.initializer()->getVarType();
 		if (!standardCheck(*variable.type, initType, &host))
 		{
 			failure = true;
@@ -176,7 +176,7 @@ void TypeCheck::caseDataDeclExtraArray(ASTDataDeclExtraArray& host, void*)
 
 void TypeCheck::caseExprConst(ASTExprConst& host, void*)
 {
-	ASTExpr* content = host.getContent();
+	ASTExpr* content = host.content;
 	content->execute(*this);
 
 	if (!host.isConstant())
@@ -193,13 +193,13 @@ void TypeCheck::caseExprConst(ASTExprConst& host, void*)
 
 void TypeCheck::caseExprAssign(ASTExprAssign& host, void*)
 {
-    host.getRVal()->execute(*this);
+    host.right->execute(*this);
     if (failure) return;
 
-	ZVarTypeId ltypeid = getLValTypeId(*host.getLVal());
+	ZVarTypeId ltypeid = getLValTypeId(*host.left);
     if (failure) return;
 
-    ZVarType const& rtype = *host.getRVal()->getVarType();
+    ZVarType const& rtype = *host.right->getVarType();
 	host.setVarType(rtype);
 
     if (!standardCheck(ltypeid, rtype, &host))
@@ -226,15 +226,15 @@ void TypeCheck::caseExprArrow(ASTExprArrow& host, void*)
 {
     // Annoyingly enough I have to treat arrowed variables as function calls
     // Get the left-hand type.
-    host.getLeft()->execute(*this);
+    host.left->execute(*this);
     if (failure) return;
 
 	// Don't need to check index here, since it'll be checked in the above
 	// ASTExprIndex.
-	bool isIndexed = host.getIndex() != NULL;
+	bool isIndexed = host.index != NULL;
 
 	// Make sure the left side is an object.
-    ZVarTypeId leftTypeId = symbolTable.getTypeId(*host.getLeft()->getVarType());
+    ZVarTypeId leftTypeId = symbolTable.getTypeId(*host.left->getVarType());
 	if (symbolTable.getType(leftTypeId)->typeClassId() != ZVARTYPE_CLASSID_CLASS)
 	{
         compileError(host, &CompileError::ArrowNotPointer);
@@ -244,18 +244,18 @@ void TypeCheck::caseExprArrow(ASTExprArrow& host, void*)
 	ZVarTypeClass& leftType = *(ZVarTypeClass*)symbolTable.getType(leftTypeId);
 	ZClass& leftClass = *symbolTable.getClass(leftType.getClassId());
 
-	Function* function = leftClass.getGetter(host.getRight());
+	Function* function = leftClass.getGetter(host.right);
 	if (!function)
 	{
         compileError(host, &CompileError::ArrowNoVar,
-					 (host.getRight() + (isIndexed ? "[]" : "")).c_str());
+					 (host.right + (isIndexed ? "[]" : "")).c_str());
         return;
 	}
 	vector<ZVarTypeId> functionParams = symbolTable.getFuncParamTypeIds(function->id);
     if (functionParams.size() != (isIndexed ? 2 : 1) || functionParams[0] != leftTypeId)
     {
         compileError(host, &CompileError::ArrowNoVar,
-					 (host.getRight() + (isIndexed ? "[]" : "")).c_str());
+					 (host.right + (isIndexed ? "[]" : "")).c_str());
         return;
     }
 
@@ -265,16 +265,16 @@ void TypeCheck::caseExprArrow(ASTExprArrow& host, void*)
 
 void TypeCheck::caseExprIndex(ASTExprIndex& host, void*)
 {
-	host.getArray()->execute(*this);
-	host.setVarType(host.getArray()->getVarType());
+	host.array->execute(*this);
+	host.setVarType(host.array->getVarType());
 
 	// The index must be a number.
-    if (host.getIndex())
+    if (host.index)
     {
-        host.getIndex()->execute(*this);
+        host.index->execute(*this);
         if (failure) return;
 
-        if (!standardCheck(ZVARTYPEID_FLOAT, *host.getIndex()->getVarType(), host.getIndex()))
+        if (!standardCheck(ZVARTYPEID_FLOAT, *host.index->getVarType(), host.index))
         {
             failure = true;
             return;
@@ -287,18 +287,18 @@ void TypeCheck::caseExprCall(ASTExprCall& host, void*)
     // Yuck. Time to disambiguate these damn functions
 
     // Build the param types
-    list<ASTExpr*> params = host.getParams();
+    vector<ASTExpr*> params = host.parameters;
     vector<ZVarTypeId> paramtypes;
     vector<int> possibleFuncIds;
 
     // If this is a simple function, we already have what we need otherwise we
     // need the type of the thing being arrowed.
-    if (host.getLeft()->isTypeArrow())
+    if (host.left->isTypeArrow())
     {
-        ASTExprArrow* lval = (ASTExprArrow*)host.getLeft();
-        lval->getLeft()->execute(*this);
+        ASTExprArrow* lval = (ASTExprArrow*)host.left;
+        lval->left->execute(*this);
         if (failure) return;
-        ZVarType const& lvaltype = *lval->getLeft()->getVarType();
+        ZVarType const& lvaltype = *lval->left->getVarType();
 
 		if (lvaltype.typeClassId() != ZVARTYPE_CLASSID_CLASS)
         {
@@ -311,7 +311,7 @@ void TypeCheck::caseExprCall(ASTExprCall& host, void*)
     }
 
     // Now add the normal parameters.
-    for (list<ASTExpr*>::iterator it = params.begin(); it != params.end(); it++)
+    for (vector<ASTExpr*>::iterator it = params.begin(); it != params.end(); it++)
     {
         (*it)->execute(*this);
         if (failure) return;
@@ -332,7 +332,7 @@ void TypeCheck::caseExprCall(ASTExprCall& host, void*)
     }
     paramstring += ")";
 
-    if (host.getLeft()->isTypeIdentifier())
+    if (host.left->isTypeIdentifier())
     {
         possibleFuncIds = symbolTable.getPossibleNodeFuncIds(&host);
 
@@ -385,7 +385,7 @@ void TypeCheck::caseExprCall(ASTExprCall& host, void*)
             }
         }
 
-        string fullname = host.getLeft()->asString();
+        string fullname = host.left->asString();
 
         if (bestmatch.size() == 0)
         {
@@ -408,11 +408,11 @@ void TypeCheck::caseExprCall(ASTExprCall& host, void*)
     {
         // Still have to deal with the (%&# arrow functions
         // Luckily I will here assert that each type's functions MUST be unique
-		ASTExprArrow& arrow = *(ASTExprArrow*)host.getLeft();
-        string name = arrow.getRight();
+		ASTExprArrow& arrow = *(ASTExprArrow*)host.left;
+        string name = arrow.right;
 
 		// Make sure the left side is an object.
-        ZVarTypeId leftTypeId = symbolTable.getTypeId(*arrow.getLeft()->getVarType());
+        ZVarTypeId leftTypeId = symbolTable.getTypeId(*arrow.left->getVarType());
 		if (symbolTable.getType(leftTypeId)->typeClassId() != ZVARTYPE_CLASSID_CLASS)
 		{
 			compileError(host, &CompileError::ArrowNotPointer);
@@ -459,9 +459,9 @@ void TypeCheck::caseExprNegate(ASTExprNegate& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::FLOAT);
 
-    if (host.getOperand()->hasDataValue())
+    if (host.operand->hasDataValue())
     {
-        long val = host.getOperand()->getDataValue();
+        long val = host.operand->getDataValue();
         host.setDataValue(-val);
     }
 }
@@ -471,10 +471,10 @@ void TypeCheck::caseExprNot(ASTExprNot& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_BOOL)) return;
     host.setVarType(ZVarType::BOOL);
 
-    if (host.getOperand()->hasDataValue())
+    if (host.operand->hasDataValue())
     {
-        long val = host.getOperand()->getDataValue();
-		host.setDataValue(!host.getOperand()->getDataValue());
+        long val = host.operand->getDataValue();
+		host.setDataValue(!host.operand->getDataValue());
     }
 }
 
@@ -483,24 +483,24 @@ void TypeCheck::caseExprBitNot(ASTExprBitNot& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::FLOAT);
 
-    if (host.getOperand()->hasDataValue())
+    if (host.operand->hasDataValue())
     {
-        long val = host.getOperand()->getDataValue();
+        long val = host.operand->getDataValue();
         host.setDataValue((~(val/10000))*10000);
     }
 }
 
 void TypeCheck::caseExprIncrement(ASTExprIncrement& host, void*)
 {
-    host.getOperand()->execute(*this);
+    host.operand->execute(*this);
     if (failure) return;
 
-	ASTExpr& operand = *host.getOperand();
+	ASTExpr& operand = *host.operand;
     if (operand.isTypeArrow() || operand.isTypeIndex())
     {
 		ASTExprArrow* arrow;
 		if (operand.isTypeArrow()) arrow = &(ASTExprArrow&)operand;
-		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).getArray();
+		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).array;
         int fid = symbolTable.getNodeId(arrow);
         symbolTable.putNodeId(&host, fid);
     }
@@ -519,15 +519,15 @@ void TypeCheck::caseExprIncrement(ASTExprIncrement& host, void*)
 
 void TypeCheck::caseExprPreIncrement(ASTExprPreIncrement& host, void*)
 {
-    host.getOperand()->execute(*this);
+    host.operand->execute(*this);
     if (failure) return;
 
-	ASTExpr& operand = *host.getOperand();
+	ASTExpr& operand = *host.operand;
     if (operand.isTypeArrow() || operand.isTypeIndex())
     {
 		ASTExprArrow* arrow;
 		if (operand.isTypeArrow()) arrow = &(ASTExprArrow&)operand;
-		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).getArray();
+		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).array;
         int fid = symbolTable.getNodeId(arrow);
         symbolTable.putNodeId(&host, fid);
     }
@@ -546,15 +546,15 @@ void TypeCheck::caseExprPreIncrement(ASTExprPreIncrement& host, void*)
 
 void TypeCheck::caseExprDecrement(ASTExprDecrement& host, void*)
 {
-    host.getOperand()->execute(*this);
+    host.operand->execute(*this);
     if (failure) return;
 
-	ASTExpr& operand = *host.getOperand();
+	ASTExpr& operand = *host.operand;
     if (operand.isTypeArrow() || operand.isTypeIndex())
     {
 		ASTExprArrow* arrow;
 		if (operand.isTypeArrow()) arrow = &(ASTExprArrow&)operand;
-		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).getArray();
+		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).array;
         int fid = symbolTable.getNodeId(arrow);
         symbolTable.putNodeId(&host, fid);
     }
@@ -573,15 +573,15 @@ void TypeCheck::caseExprDecrement(ASTExprDecrement& host, void*)
 
 void TypeCheck::caseExprPreDecrement(ASTExprPreDecrement& host, void*)
 {
-    host.getOperand()->execute(*this);
+    host.operand->execute(*this);
     if (failure) return;
 
-	ASTExpr& operand = *host.getOperand();
+	ASTExpr& operand = *host.operand;
     if (operand.isTypeArrow() || operand.isTypeIndex())
     {
 		ASTExprArrow* arrow;
 		if (operand.isTypeArrow()) arrow = &(ASTExprArrow&)operand;
-		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).getArray();
+		else arrow = (ASTExprArrow*)((ASTExprIndex&)operand).array;
         int fid = symbolTable.getNodeId(arrow);
         symbolTable.putNodeId(&host, fid);
     }
@@ -603,10 +603,10 @@ void TypeCheck::caseExprAnd(ASTExprAnd& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_BOOL, ZVARTYPEID_BOOL)) return;
 	host.setVarType(ZVarType::BOOL);
 
-	if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+	if (host.left->hasDataValue() && host.right->hasDataValue())
 	{
-		long firstval = host.getFirstOperand()->getDataValue();
-		long secondval = host.getSecondOperand()->getDataValue();
+		long firstval = host.left->getDataValue();
+		long secondval = host.right->getDataValue();
 		host.setDataValue(firstval && secondval);
 	}
 }
@@ -616,10 +616,10 @@ void TypeCheck::caseExprOr(ASTExprOr& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_BOOL, ZVARTYPEID_BOOL)) return;
 	host.setVarType(ZVarType::BOOL);
 
-	if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+	if (host.left->hasDataValue() && host.right->hasDataValue())
 	{
-		long firstval = host.getFirstOperand()->getDataValue();
-		long secondval = host.getSecondOperand()->getDataValue();
+		long firstval = host.left->getDataValue();
+		long secondval = host.right->getDataValue();
 		host.setDataValue(firstval || secondval);
 	}
 }
@@ -629,10 +629,10 @@ void TypeCheck::caseExprGT(ASTExprGT& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::BOOL);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
 		host.setDataValue(firstval > secondval);
     }
 }
@@ -642,10 +642,10 @@ void TypeCheck::caseExprGE(ASTExprGE& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::BOOL);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
 		host.setDataValue(firstval >= secondval);
     }
 }
@@ -655,10 +655,10 @@ void TypeCheck::caseExprLT(ASTExprLT& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::BOOL);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
 		host.setDataValue(firstval < secondval);
     }
 }
@@ -668,22 +668,22 @@ void TypeCheck::caseExprLE(ASTExprLE& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::BOOL);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
 		host.setDataValue(firstval <= secondval);
     }
 }
 
 void TypeCheck::caseExprEQ(ASTExprEQ& host, void*)
 {
-	host.getFirstOperand()->execute(*this);
+	host.left->execute(*this);
 	if (failure) return;
-	host.getSecondOperand()->execute(*this);
+	host.right->execute(*this);
 	if (failure) return;
 
-	if (!standardCheck(*host.getFirstOperand()->getVarType(), *host.getSecondOperand()->getVarType(), &host))
+	if (!standardCheck(*host.left->getVarType(), *host.right->getVarType(), &host))
 	{
 		failure = true;
 		return;
@@ -691,22 +691,22 @@ void TypeCheck::caseExprEQ(ASTExprEQ& host, void*)
 
     host.setVarType(ZVarType::BOOL);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
 		host.setDataValue(firstval == secondval);
     }
 }
 
 void TypeCheck::caseExprNE(ASTExprNE& host, void*)
 {
-	host.getFirstOperand()->execute(*this);
+	host.left->execute(*this);
 	if (failure) return;
-	host.getSecondOperand()->execute(*this);
+	host.right->execute(*this);
 	if (failure) return;
 
-	if (!standardCheck(*host.getFirstOperand()->getVarType(), *host.getSecondOperand()->getVarType(), &host))
+	if (!standardCheck(*host.left->getVarType(), *host.right->getVarType(), &host))
 	{
 		failure = true;
 		return;
@@ -714,10 +714,10 @@ void TypeCheck::caseExprNE(ASTExprNE& host, void*)
 
     host.setVarType(ZVarType::BOOL);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
 		host.setDataValue(firstval != secondval);
     }
 }
@@ -727,10 +727,10 @@ void TypeCheck::caseExprPlus(ASTExprPlus& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::FLOAT);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
         host.setDataValue(firstval + secondval);
     }
 }
@@ -740,10 +740,10 @@ void TypeCheck::caseExprMinus(ASTExprMinus& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::FLOAT);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
         host.setDataValue(firstval - secondval);
     }
 }
@@ -753,10 +753,10 @@ void TypeCheck::caseExprTimes(ASTExprTimes& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::FLOAT);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
         double temp = ((double)secondval)/10000.0;
         host.setDataValue((long)(firstval * temp));
     }
@@ -767,10 +767,10 @@ void TypeCheck::caseExprDivide(ASTExprDivide& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::FLOAT);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
 
         if (secondval == 0)
         {
@@ -787,10 +787,10 @@ void TypeCheck::caseExprModulo(ASTExprModulo& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::FLOAT);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
 
         if (secondval == 0)
         {
@@ -808,10 +808,10 @@ void TypeCheck::caseExprBitAnd(ASTExprBitAnd& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::FLOAT);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
         host.setDataValue(((firstval/10000)&(secondval/10000))*10000);
     }
 }
@@ -821,10 +821,10 @@ void TypeCheck::caseExprBitOr(ASTExprBitOr& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::FLOAT);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
         host.setDataValue(((firstval/10000)|(secondval/10000))*10000);
     }
 }
@@ -834,10 +834,10 @@ void TypeCheck::caseExprBitXor(ASTExprBitXor& host, void*)
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
     host.setVarType(ZVarType::FLOAT);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        long secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        long secondval = host.right->getDataValue();
         host.setDataValue(((firstval/10000)^(secondval/10000))*10000);
     }
 }
@@ -845,20 +845,20 @@ void TypeCheck::caseExprLShift(ASTExprLShift& host, void*)
 {
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
 
-    if (host.getSecondOperand()->hasDataValue())
+    if (host.right->hasDataValue())
     {
-        if (host.getSecondOperand()->getDataValue() % 10000)
+        if (host.right->getDataValue() % 10000)
         {
             compileError(host, &CompileError::ShiftNotInt);
-            host.getSecondOperand()->setDataValue(10000*(host.getSecondOperand()->getDataValue()/10000));
+            host.right->setDataValue(10000*(host.right->getDataValue()/10000));
         }
     }
     host.setVarType(ZVarType::FLOAT);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        int secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        int secondval = host.right->getDataValue();
         host.setDataValue(((firstval/10000)<<(secondval/10000))*10000);
     }
 }
@@ -866,20 +866,20 @@ void TypeCheck::caseExprRShift(ASTExprRShift& host, void*)
 {
 	if (!checkExprTypes(host, ZVARTYPEID_FLOAT, ZVARTYPEID_FLOAT)) return;
 
-    if (host.getSecondOperand()->hasDataValue())
+    if (host.right->hasDataValue())
     {
-        if (host.getSecondOperand()->getDataValue() % 10000)
+        if (host.right->getDataValue() % 10000)
         {
             compileError(host, &CompileError::ShiftNotInt);
-            host.getSecondOperand()->setDataValue(10000*(host.getSecondOperand()->getDataValue()/10000));
+            host.right->setDataValue(10000*(host.right->getDataValue()/10000));
         }
     }
     host.setVarType(ZVarType::FLOAT);
 
-    if (host.getFirstOperand()->hasDataValue() && host.getSecondOperand()->hasDataValue())
+    if (host.left->hasDataValue() && host.right->hasDataValue())
     {
-        long firstval = host.getFirstOperand()->getDataValue();
-        int secondval = host.getSecondOperand()->getDataValue();
+        long firstval = host.left->getDataValue();
+        int secondval = host.right->getDataValue();
         host.setDataValue(((firstval/10000)>>(secondval/10000))*10000);
     }
 }
@@ -972,22 +972,22 @@ bool TypeCheck::standardCheck(ZVarType const& targetType, ZVarType const& source
 
 bool TypeCheck::checkExprTypes(ASTUnaryExpr& expr, ZVarTypeId type)
 {
-	expr.getOperand()->execute(*this);
+	expr.operand->execute(*this);
 	if (failure) return false;
-	failure = !standardCheck(type, *expr.getOperand()->getVarType(), &expr);
+	failure = !standardCheck(type, *expr.operand->getVarType(), &expr);
 	return !failure;
 }
 
 bool TypeCheck::checkExprTypes(ASTBinaryExpr& expr, ZVarTypeId firstType, ZVarTypeId secondType)
 {
-	expr.getFirstOperand()->execute(*this);
+	expr.left->execute(*this);
 	if (failure) return false;
-	failure = !standardCheck(firstType, *expr.getFirstOperand()->getVarType(), &expr);
+	failure = !standardCheck(firstType, *expr.left->getVarType(), &expr);
 	if (failure) return false;
 
-	expr.getSecondOperand()->execute(*this);
+	expr.right->execute(*this);
 	if (failure) return false;
-	failure = !standardCheck(secondType, *expr.getSecondOperand()->getVarType(), &expr);
+	failure = !standardCheck(secondType, *expr.right->getVarType(), &expr);
 	return !failure;
 }
 
@@ -1019,15 +1019,15 @@ void GetLValType::caseExprArrow(ASTExprArrow& host, void*)
 {
 	SymbolTable& symbolTable = typeCheck.symbolTable;
 
-    host.getLeft()->execute(typeCheck);
+    host.left->execute(typeCheck);
     if (typeCheck.hasFailed()) return;
 
 	// Don't need to check index here, since it'll be checked in the above
 	// ASTExprIndex.
-	bool isIndexed = host.getIndex() != NULL;
+	bool isIndexed = host.index != NULL;
 
 	// Make sure the left side is an object.
-    ZVarTypeId leftTypeId = symbolTable.getTypeId(*host.getLeft()->getVarType());
+    ZVarTypeId leftTypeId = symbolTable.getTypeId(*host.left->getVarType());
 	if (symbolTable.getType(leftTypeId)->typeClassId() != ZVARTYPE_CLASSID_CLASS)
 	{
         typeCheck.compileError(host, &CompileError::ArrowNotPointer);
@@ -1037,12 +1037,12 @@ void GetLValType::caseExprArrow(ASTExprArrow& host, void*)
 	ZVarTypeClass& leftType = *(ZVarTypeClass*)symbolTable.getType(leftTypeId);
 	ZClass& leftClass = *symbolTable.getClass(leftType.getClassId());
 
-	Function* function = leftClass.getSetter(host.getRight());
+	Function* function = leftClass.getSetter(host.right);
     if (!function)
     {
         typeCheck.compileError(
 				host, &CompileError::ArrowNoVar,
-				(host.getRight() + (isIndexed ? "[]" : "")).c_str());
+				(host.right + (isIndexed ? "[]" : "")).c_str());
         return;
     }
 	vector<ZVarTypeId> functionParams = symbolTable.getFuncParamTypeIds(function->id);
@@ -1050,7 +1050,7 @@ void GetLValType::caseExprArrow(ASTExprArrow& host, void*)
     {
         typeCheck.compileError(
 				host, &CompileError::ArrowNoVar,
-				(host.getRight() + (isIndexed ? "[]" : "")).c_str());
+				(host.right + (isIndexed ? "[]" : "")).c_str());
         return;
     }
 
@@ -1077,22 +1077,22 @@ void GetLValType::caseExprIdentifier(ASTExprIdentifier& host, void*)
 void GetLValType::caseExprIndex(ASTExprIndex& host, void*)
 {
 	// Arrows just fall back on the arrow implementation.
-	if (host.getArray()->isTypeArrow()) host.getArray()->execute(*this);
+	if (host.array->isTypeArrow()) host.array->execute(*this);
 
 	else
 	{
 		host.execute(typeCheck);
-		typeId = typeCheck.symbolTable.getTypeId(*host.getArray()->getVarType());
+		typeId = typeCheck.symbolTable.getTypeId(*host.array->getVarType());
 	}
 
 	// The index must be a number.
-	if (host.getIndex())
+	if (host.index)
 	{
-		host.getIndex()->execute(typeCheck);
+		host.index->execute(typeCheck);
 
 		if (typeCheck.hasFailed()) return;
 
-		if (!typeCheck.standardCheck(ZVARTYPEID_FLOAT, *host.getIndex()->getVarType(), host.getIndex()))
+		if (!typeCheck.standardCheck(ZVARTYPEID_FLOAT, *host.index->getVarType(), host.index))
 		{
 			typeCheck.fail();
 			return;

--- a/src/parser/UtilVisitors.cpp
+++ b/src/parser/UtilVisitors.cpp
@@ -115,72 +115,72 @@ void RecursiveVisitor::caseProgram(ASTProgram& host, void* param)
 
 void RecursiveVisitor::caseBlock(ASTBlock& host, void* param)
 {
-	recurse(host, param, host.getStatements());
+	recurse(host, param, host.statements);
 }
 
 void RecursiveVisitor::caseStmtIf(ASTStmtIf& host, void* param)
 {
-	recurse(host.getCondition(), param);
+	recurse(host.condition, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getStmt(), param);
+	recurse(host.thenStatement, param);
 }
 
 void RecursiveVisitor::caseStmtIfElse(ASTStmtIfElse& host, void* param)
 {
 	caseStmtIf(host, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getElseStmt(), param);
+	recurse(host.elseStatement, param);
 }
 
 void RecursiveVisitor::caseStmtSwitch(ASTStmtSwitch& host, void* param)
 {
-	recurse(host.getKey(), param);
+	recurse(host.key, param);
 	if (breakRecursion(host)) return;
-	recurse(host, param, host.getCases());
+	recurse(host, param, host.cases);
 }
 
 void RecursiveVisitor::caseSwitchCases(ASTSwitchCases& host, void* param)
 {
-	recurse(host, param, host.getCases());
+	recurse(host, param, host.cases);
 	if (breakRecursion(host)) return;
-	recurse(host.getBlock(), param);
+	recurse(host.block, param);
 }
 
 void RecursiveVisitor::caseStmtFor(ASTStmtFor& host, void* param)
 {
-	recurse(host.getPrecondition(), param);
+	recurse(host.setup, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getTerminationCondition(), param);
+	recurse(host.test, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getIncrement(), param);
+	recurse(host.increment, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getStmt(), param);
+	recurse(host.body, param);
 }
 
 void RecursiveVisitor::caseStmtWhile(ASTStmtWhile& host, void* param)
 {
-	recurse(host.getCond(), param);
+	recurse(host.test, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getStmt(), param);
+	recurse(host.body, param);
 }
 
 void RecursiveVisitor::caseStmtDo(ASTStmtDo& host, void* param)
 {
-	recurse(host.getStmt(), param);
+	recurse(host.body, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getCond(), param);
+	recurse(host.test, param);
 }
 
 void RecursiveVisitor::caseStmtReturnVal(ASTStmtReturnVal& host, void* param)
 {
-	recurse(host.getReturnValue(), param);
+	recurse(host.value, param);
 }
 
 // Declarations
 
 void RecursiveVisitor::caseScript(ASTScript& host, void* param)
 {
-	recurse(host.getType(), param);
+	recurse(host.type, param);
 	if (breakRecursion(host)) return;
 	recurse(host, param, host.types);
 	if (breakRecursion(host)) return;
@@ -193,7 +193,7 @@ void RecursiveVisitor::caseFuncDecl(ASTFuncDecl& host, void* param)
 {
 	recurse(host.returnType, param);
 	if (breakRecursion(host)) return;
-	recurse(host, param, host.getParameters());
+	recurse(host, param, host.parameters);
 	if (breakRecursion(host)) return;
 	recurse(host.block, param);
 }
@@ -202,7 +202,7 @@ void RecursiveVisitor::caseDataDeclList(ASTDataDeclList& host, void* param)
 {
 	recurse(host.baseType, param);
 	if (breakRecursion(host)) return;
-	recurse(host, param, host.getDeclarations());
+	recurse(host, param, host.declarations());
 }
 
 void RecursiveVisitor::caseDataDecl(ASTDataDecl& host, void* param)
@@ -211,7 +211,7 @@ void RecursiveVisitor::caseDataDecl(ASTDataDecl& host, void* param)
 	if (breakRecursion(host)) return;
 	recurse(host, param, host.extraArrays);
 	if (breakRecursion(host)) return;
-	recurse(host.getInitializer(), param);
+	recurse(host.initializer(), param);
 }
 
 void RecursiveVisitor::caseDataDeclExtraArray(
@@ -222,221 +222,221 @@ void RecursiveVisitor::caseDataDeclExtraArray(
 
 void RecursiveVisitor::caseTypeDef(ASTTypeDef& host, void* param)
 {
-	recurse(host.getType(), param);
+	recurse(host.type, param);
 }
 
 // Expressions
 
 void RecursiveVisitor::caseExprConst(ASTExprConst& host, void* param)
 {
-	recurse(host.getContent(), param);
+	recurse(host.content, param);
 }
 
 void RecursiveVisitor::caseExprAssign(ASTExprAssign& host, void* param)
 {
-	recurse(host.getLVal(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getRVal(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprArrow(ASTExprArrow& host, void* param)
 {
-	recurse(host.getLeft(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getIndex(), param);
+	recurse(host.index, param);
 }
 
 void RecursiveVisitor::caseExprIndex(ASTExprIndex& host, void* param)
 {
-	recurse(host.getArray(), param);
+	recurse(host.array, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getIndex(), param);
+	recurse(host.index, param);
 }
 
 void RecursiveVisitor::caseExprCall(ASTExprCall& host, void* param)
 {
-	//recurse(host.getLeft(), param);
+	//recurse(host.left, param);
 	//if (breakRecursion(host)) return;
-	recurse(host, param, host.getParams());
+	recurse(host, param, host.parameters);
 }
 
 void RecursiveVisitor::caseExprNegate(ASTExprNegate& host, void* param)
 {
-	recurse(host.getOperand(), param);
+	recurse(host.operand, param);
 }
 
 void RecursiveVisitor::caseExprNot(ASTExprNot& host, void* param)
 {
-	recurse(host.getOperand(), param);
+	recurse(host.operand, param);
 }
 
 void RecursiveVisitor::caseExprBitNot(ASTExprBitNot& host, void* param)
 {
-	recurse(host.getOperand(), param);
+	recurse(host.operand, param);
 }
 
 void RecursiveVisitor::caseExprIncrement(ASTExprIncrement& host, void* param)
 {
-	recurse(host.getOperand(), param);
+	recurse(host.operand, param);
 }
 
 void RecursiveVisitor::caseExprPreIncrement(
 		ASTExprPreIncrement& host, void* param)
 {
-	recurse(host.getOperand(), param);
+	recurse(host.operand, param);
 }
 
 void RecursiveVisitor::caseExprDecrement(ASTExprDecrement& host, void* param)
 {
-	recurse(host.getOperand(), param);
+	recurse(host.operand, param);
 }
 
 void RecursiveVisitor::caseExprPreDecrement(
 		ASTExprPreDecrement& host, void* param)
 {
-	recurse(host.getOperand(), param);
+	recurse(host.operand, param);
 }
 
 void RecursiveVisitor::caseExprAnd(ASTExprAnd& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprOr(ASTExprOr& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprGT(ASTExprGT& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprGE(ASTExprGE& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprLT(ASTExprLT& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprLE(ASTExprLE& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprEQ(ASTExprEQ& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprNE(ASTExprNE& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprPlus(ASTExprPlus& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprMinus(ASTExprMinus& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprTimes(ASTExprTimes& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprDivide(ASTExprDivide& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprModulo(ASTExprModulo& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprBitAnd(ASTExprBitAnd& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprBitOr(ASTExprBitOr& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprBitXor(ASTExprBitXor& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprLShift(ASTExprLShift& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 void RecursiveVisitor::caseExprRShift(ASTExprRShift& host, void* param)
 {
-	recurse(host.getFirstOperand(), param);
+	recurse(host.left, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSecondOperand(), param);
+	recurse(host.right, param);
 }
 
 // Literals
 
 void RecursiveVisitor::caseNumberLiteral(ASTNumberLiteral& host, void* param)
 {
-	recurse(host.getValue(), param);
+	recurse(host.value, param);
 }
 
 void RecursiveVisitor::caseArrayLiteral(ASTArrayLiteral& host, void* param)
 {
-	recurse(host.getType(), param);
+	recurse(host.type, param);
 	if (breakRecursion(host)) return;
-	recurse(host.getSize(), param);
+	recurse(host.size, param);
 	if (breakRecursion(host)) return;
-	recurse(host, param, host.getElements());
+	recurse(host, param, host.elements);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/parser/ZScript.cpp
+++ b/src/parser/ZScript.cpp
@@ -109,9 +109,9 @@ Script::Script(Program& program, ASTScript* script) : node(script)
 	scope->varDeclsDeprecated = true;
 }
 
-string Script::getName() const {return node->getName();}
+string Script::getName() const {return node->name;}
 
-ScriptType Script::getType() const {return node->getType()->getType();}
+ScriptType Script::getType() const {return node->type->type;}
 
 Function* Script::getRun() const
 {

--- a/src/parser/ffscript.ypp
+++ b/src/parser/ffscript.ypp
@@ -34,13 +34,13 @@ extern YYLTYPE noloc;
 #define PREFIX(klass, dd, d2, ad) \
 	klass* prefix = new klass(ad); \
 	ASTExpr* operand = (ASTExpr*)d2; \
-	prefix->setOperand(operand); \
+	prefix->operand = operand; \
 	dd = prefix;
 
 #define POSTFIX(klass, dd, d1, ad) \
 	klass* postfix = new klass(ad); \
 	ASTExpr* operand = (ASTExpr*)d1; \
-	postfix->setOperand(operand); \
+	postfix->operand = operand; \
 	dd = postfix;
 
 #define BINARY(klass, dd, d1, d3, ad) \
@@ -156,7 +156,7 @@ GlobalStmt : Script {$$ = $1;}
 DataDeclExtraArray :
 	LBRACKET DataDeclExtraArray_SizeList RBRACKET {
 			ASTDataDeclExtraArray* extraArray = (ASTDataDeclExtraArray*)$2;
-			extraArray->updateLocation(@$);
+			extraArray->location = @$;
 			$$ = extraArray;}
 	| LBRACKET RBRACKET {$$ = new ASTDataDeclExtraArray(@$);}
 	;
@@ -166,7 +166,7 @@ DataDeclExtraArray_SizeList :
 			ASTDataDeclExtraArray* extraArray = (ASTDataDeclExtraArray*)$1;
 			ASTExpr* size = (ASTExpr*)$3;
 			extraArray->dimensions.push_back(size);
-			extraArray->updateLocation(@$);
+			extraArray->location = @$;
 			$$ = extraArray;}
 	| ConstExpr {
 			ASTExpr* size = (ASTExpr*)$1;
@@ -181,7 +181,7 @@ DataDeclList : Type DataDeclList_1 {
 		ASTVarType* type = (ASTVarType*)$1;
 		ASTDataDeclList* list = (ASTDataDeclList*)$2;
 		list->baseType = type;
-		list->updateLocation(@$);
+		list->location = @$;
 		$$ = list;}
 	;
 
@@ -190,7 +190,7 @@ DataDeclList_1 :
 			ASTDataDeclList* list = (ASTDataDeclList*)$1;
 			ASTDataDecl* element = (ASTDataDecl*)$3;
 			list->addDeclaration(element);
-			list->updateLocation(@$);
+			list->location = @$;
 			$$ = list;}
 	| DataDeclList_Element {
 			ASTDataDecl* element = (ASTDataDecl*)$1;
@@ -203,8 +203,8 @@ DataDeclList_Element :
 	DataDeclList_Element_1 ASSIGN Expr {
 			ASTDataDecl* element = (ASTDataDecl*)$1;
 			ASTExpr* initializer = (ASTExpr*)$3;
-			element->setInitializer(initializer);
-			element->updateLocation(@$);
+			element->initializer(initializer);
+			element->location = @$;
 			$$ = element;}
 	| DataDeclList_Element_1 {$$ = $1;}
 	;
@@ -214,7 +214,7 @@ DataDeclList_Element_1 :
 			ASTDataDecl* element = (ASTDataDecl*)$1;
 			ASTDataDeclExtraArray* extraArray = (ASTDataDeclExtraArray*)$2;
 			element->extraArrays.push_back(extraArray);
-			element->updateLocation(@$);
+			element->location = @$;
 			$$ = element;}
 	| IDENTIFIER {
 			ASTString* name = (ASTString*)$1;
@@ -230,7 +230,7 @@ DataDecl : Type DataDecl_1 {
 		ASTVarType* type = (ASTVarType*)$1;
 		ASTDataDecl* data = (ASTDataDecl*)$2;
 		data->baseType = type;
-		data->updateLocation(@$);
+		data->location = @$;
 		$$ = data;}
 	;
 
@@ -240,8 +240,8 @@ DataDecl_1 :
 	| DataDecl_2 ASSIGN Expr {
 			ASTDataDecl* data = (ASTDataDecl*)$1;
 			ASTExpr* initializer = (ASTExpr*)$3;
-			data->setInitializer(initializer);
-			data->updateLocation(@$);
+			data->initializer(initializer);
+			data->location = @$;
 			$$ = data;}
 	;
 
@@ -250,7 +250,7 @@ DataDecl_2 :
 			ASTDataDecl* data = (ASTDataDecl*)$1;
 			ASTDataDeclExtraArray* extraArray = (ASTDataDeclExtraArray*)$2;
 			data->extraArrays.push_back(extraArray);
-			data->updateLocation(@$);
+			data->location = @$;
 			$$ = data;}
 	| IDENTIFIER {
 			ASTString* name = (ASTString*)$1;
@@ -272,7 +272,7 @@ FuncDecl :
 			func->returnType = returnType;
 			func->name = name->getValue();
 			func->block = block;
-			func->updateLocation(@$);
+			func->location = @$;
 			$$ = func;
 			delete name;}
 	| Type IDENTIFIER LPAREN RPAREN Block {
@@ -291,13 +291,13 @@ FuncDecl_ParamList :
 	FuncDecl_ParamList COMMA DataDecl {
 			ASTFuncDecl* func = (ASTFuncDecl*)$1;
 			ASTDataDecl* param = (ASTDataDecl*)$3;
-			func->addParameter(param);
-			func->updateLocation(@$);
+			func->parameters.push_back(param);
+			func->location = @$;
 			$$ = func;}
 	| DataDecl {
 			ASTDataDecl* param = (ASTDataDecl*)$1;
 			ASTFuncDecl* func = new ASTFuncDecl(@$);
-			func->addParameter(param);
+			func->parameters.push_back(param);
 			$$ = func;}
 	;
 
@@ -316,9 +316,9 @@ Script : ScriptType SCRIPT IDENTIFIER ScriptBlock {
 			ASTScriptType* type = (ASTScriptType*)$1;
 			ASTString* name = (ASTString*)$3;
 			ASTScript* script = (ASTScript*)$4;
-			script->setType(type);
-			script->setName(name->getValue());
-			script->updateLocation(@$);
+			script->type = type;
+			script->name = name->getValue();
+			script->location = @$;
 			$$ = script;
 			delete name;}
 	;
@@ -343,7 +343,7 @@ ScriptStmtList :
 		ASTScript* script = (ASTScript*)$1;
 		ASTDecl* declaration = (ASTDecl*)$2;
 		script->addDeclaration(*declaration);
-		script->updateLocation(@$);
+		script->location = @$;
 		$$ = script;}
 	| ScriptStmt {
 		ASTScript* script = new ASTScript(@$);
@@ -381,12 +381,12 @@ Block : LBRACE StmtList RBRACE  {$$ = $2;}
 StmtList : Stmt {
 			ASTStmt* stmt = (ASTStmt*)$1;
 			ASTBlock *block = new ASTBlock(@1);
-			block->addStatement(stmt);
+			block->statements.push_back(stmt);
 			$$ = block;}
   | StmtList Stmt {
 			ASTBlock *block = (ASTBlock *)$1;
 			ASTStmt *stmt = (ASTStmt *)$2;
-			block->addStatement(stmt);
+			block->statements.push_back(stmt);
 			$$ = block;}
 	;
 
@@ -442,8 +442,8 @@ Identifier :
 	| Identifier DOT IDENTIFIER {
 		ASTExprIdentifier* identifier = (ASTExprIdentifier*)$1;
 		ASTString* name = (ASTString *)$3;
-		identifier->appendComponent(name->getValue());
-		identifier->updateLocation(@$);
+		identifier->components.push_back(name->getValue());
+		identifier->location = @$;
 		$$ = identifier;
 		delete name;}
 	;
@@ -452,14 +452,14 @@ FunctionCall :
 	Expr_2 LPAREN RPAREN {
 		ASTExprCall* call = new ASTExprCall(@$);
 		ASTExpr* left = (ASTExpr*)$1;
-		call->setLeft(left);
-		call->updateLocation(@$);
+		call->left = left;
+		call->location = @$;
 		$$ = call;}
 	| Expr_2 LPAREN FunctionCallArgs RPAREN {
 		ASTExpr* left = (ASTExpr*)$1;
 		ASTExprCall* call = (ASTExprCall*)$3;
-		call->setLeft(left);
-		call->updateLocation(@$);
+		call->left = left;
+		call->location = @$;
 		$$ = call;}
 	;
 
@@ -467,13 +467,13 @@ FunctionCallArgs :
 	Expr {
 		ASTExprCall* call = new ASTExprCall(@$);
 		ASTExpr* e = (ASTExpr*)$1;
-		call->addParam(e);
+		call->parameters.push_back(e);
 		$$ = call;}
 	| FunctionCallArgs COMMA Expr {
 		ASTExprCall* call = (ASTExprCall*)$1;
 		ASTExpr* e = (ASTExpr*)$3;
-		call->addParam(e);
-		call->updateLocation(@$);
+		call->parameters.push_back(e);
+		call->location = @$;
 		$$ = call;}
 	;
 
@@ -485,13 +485,13 @@ BoolConstant :
 ArrayLiteral :
 	LBRACE ArrayLiteralList RBRACE {
 			ASTArrayLiteral* al = (ASTArrayLiteral*)$2;
-			al->updateLocation(@$);
+			al->location = @$;
 			$$ = al;}
 	| LPAREN Type LBRACKET RBRACKET RPAREN LBRACE ArrayLiteralList RBRACE {
 			ASTVarType* type = (ASTVarType*)$2;
 			ASTArrayLiteral* al = (ASTArrayLiteral*)$7;
 			al->setType(type);
-			al->updateLocation(@$);
+			al->location = @$;
 			$$ = al;}
 	| LPAREN Type LBRACKET ConstExpr RBRACKET RPAREN LBRACE ArrayLiteralList RBRACE {
 			ASTVarType* type = (ASTVarType*)$2;
@@ -499,7 +499,7 @@ ArrayLiteral :
 			ASTArrayLiteral* al = (ASTArrayLiteral*)$8;
 			al->setType(type);
 			al->setSize(size);
-			al->updateLocation(@$);
+			al->location = @$;
 			$$ = al;}
 	| LPAREN Type LBRACKET RBRACKET RPAREN LBRACE RBRACE {
 			ASTVarType* type = (ASTVarType*)$2;
@@ -540,7 +540,7 @@ Expr_1 : Identifier {$$ = $1;}
 			ASTString* as = (ASTString*)$1;
 			char val[15];
 			sprintf(val, "%d", as->getValue().at(1));
-			$$ = new ASTNumberLiteral(new ASTFloat(val, 0, @$), @$);}
+			$$ = new ASTNumberLiteral(new ASTFloat(val, (ASTFloat::Type)0, @$), @$);}
 	| QUOTEDSTRING {
 			ASTString* rawstring = (ASTString*)$1;
 			ASTStringLiteral* str = new ASTStringLiteral(*rawstring);
@@ -715,41 +715,41 @@ IfStmt : IF LPAREN Expr RPAREN Stmt {ASTExpr *cond = (ASTExpr *)$3;
 SwitchStmt : SWITCH LPAREN Expr RPAREN LBRACE SwitchStmt1 RBRACE {
 		ASTExpr* key = (ASTExpr*)$3;
 		ASTStmtSwitch* sw = (ASTStmtSwitch*)$6;
-		sw->setKey(key);
+		sw->key = key;
 		$$ = sw;}
 	;
 SwitchStmt1 : SwitchCases StmtList {
 			ASTStmtSwitch* sw = new ASTStmtSwitch(@$);
 			ASTSwitchCases* cases = (ASTSwitchCases*)$1;
 			ASTBlock* block = (ASTBlock*)$2;
-			cases->setBlock(block);
-			sw->addCases(cases);
+			cases->block = block;
+			sw->cases.push_back(cases);
 			$$ = sw;}
 	| SwitchStmt1 SwitchCases StmtList {
 			ASTStmtSwitch* sw = (ASTStmtSwitch*)$1;
 			ASTSwitchCases* cases = (ASTSwitchCases*)$2;
 			ASTBlock* block = (ASTBlock*)$3;
-			cases->setBlock(block);
-			sw->addCases(cases);
+			cases->block;
+			sw->cases.push_back(cases);
 			$$ = sw;}
 	;
 SwitchCases : CASE ConstExpr COLON {
 			ASTSwitchCases* cases = new ASTSwitchCases(@$);
 			ASTExprConst* key = (ASTExprConst*)$2;
-			cases->addCase(key);
+			cases->cases.push_back(key);
 			$$ = cases;}
 	| DEFAULT COLON {
 			ASTSwitchCases* cases = new ASTSwitchCases(@$);
-			cases->addDefaultCase();
+			cases->isDefault = true;
 			$$ = cases;}
 	| SwitchCases CASE ConstExpr COLON {
 			ASTSwitchCases* cases = (ASTSwitchCases*)$1;
 			ASTExprConst* key = (ASTExprConst*)$3;
-			cases->addCase(key);
+			cases->cases.push_back(key);
 			$$ = cases;}
 	| SwitchCases DEFAULT COLON {
 			ASTSwitchCases* cases = (ASTSwitchCases*)$1;
-			cases->addDefaultCase();
+			cases->isDefault = true;
 			$$ = cases;}
 	;
 


### PR DESCRIPTION
All the AST node classes will have working copy constructors, assignment
operators, etc.

Add the AST::clone and AST::execute functions that will clone or execute
a single (potentially null) node, or a list or vector of nodes.

Create parser/CompilerUtils.h. Add deleteElements helper function that
deletes a vector or list of pointers for you. As a result the AST node
destructors and assignment operators are a lot more concise.